### PR TITLE
Convert Streamlit app to Flask

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
-import streamlit as st
-import numpy as np
-import tempfile
+from flask import Flask, render_template, request, jsonify
 import io
+import tempfile
 
 # Try to import trimesh first; fall back to numpy-stl if not available
 try:
@@ -16,109 +15,88 @@ except Exception:
         npmesh = None
         MESH_BACKEND = None
 
+app = Flask(__name__)
+
+
 def load_mesh(file_bytes):
     """Load STL and return bounding box dimensions (mm) and volume (mm^3)."""
     if MESH_BACKEND == 'trimesh':
-        try:
-            mesh = trimesh.load(io.BytesIO(file_bytes), file_type='stl')
-            bbox = mesh.bounding_box.extents
-            volume = mesh.volume
-            return bbox, volume
-        except Exception as e:
-            st.error(f"Ошибка при чтении STL: {e}")
-            return None, None
+        mesh = trimesh.load(io.BytesIO(file_bytes), file_type='stl')
+        bbox = mesh.bounding_box.extents
+        volume = mesh.volume
+        return bbox, volume
     elif MESH_BACKEND == 'numpy-stl':
-        try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix='.stl') as tmp:
-                tmp.write(file_bytes)
-                tmp.flush()
-                m = npmesh.Mesh.from_file(tmp.name)
-            bbox_dims = m.max_ - m.min_
-            volume, _, _ = m.get_mass_properties()
-            return bbox_dims, volume
-        except Exception as e:
-            st.error(f"Ошибка при чтении STL: {e}")
-            return None, None
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.stl') as tmp:
+            tmp.write(file_bytes)
+            tmp.flush()
+            m = npmesh.Mesh.from_file(tmp.name)
+        bbox_dims = m.max_ - m.min_
+        volume, _, _ = m.get_mass_properties()
+        return bbox_dims, volume
     else:
-        st.error("Невозможно импортировать библиотеки для работы с STL.")
-        return None, None
+        raise RuntimeError('No STL backend available')
 
-def compute_costs(volume_cm3, params):
-    cost_fdm = volume_cm3 * params['price_filament'] + volume_cm3 * params['time_coef_fdm'] * params['price_machine_hour']
-    cost_dlp = volume_cm3 * params['price_resin'] + volume_cm3 * params['time_coef_dlp'] * params['price_machine_hour']
-    return cost_fdm, cost_dlp
 
-side_text = """
-## Справка
-1. Загрузите STL-файл модели.
-2. Укажите желаемый наибольший габарит (мм). Масштаб будет рассчитан автоматически.
-3. При необходимости измените параметры стоимости.
-4. Итоговые цены учитывают материал и машинное время.
-"""
+@app.route('/')
+def index():
+    return render_template('index.html')
 
-st.sidebar.markdown(side_text)
 
-st.title("3D-Print Cost Estimator")
+@app.route('/estimate', methods=['POST'])
+def estimate():
+    file = request.files.get('stl_file')
+    if file is None or file.filename == '':
+        return jsonify(error='Файл STL обязателен'), 400
+    if not file.filename.lower().endswith('.stl'):
+        return jsonify(error='Неверный формат файла'), 400
+    try:
+        bbox, volume_mm3 = load_mesh(file.read())
+    except Exception as e:
+        return jsonify(error=f'Ошибка при чтении STL: {e}'), 400
 
-uploaded_file = st.file_uploader("Загрузите STL-файл", type=['stl'])
+    try:
+        target_dim = float(request.form.get('target_dim', ''))
+        if target_dim <= 0:
+            raise ValueError
+    except Exception:
+        return jsonify(error='Некорректное значение габарита'), 400
 
-if uploaded_file is not None:
-    file_bytes = uploaded_file.read()
-    dims, volume_mm3 = load_mesh(file_bytes)
-    if dims is None:
-        st.stop()
+    def get_param(name, default):
+        try:
+            val = float(request.form.get(name, default))
+            if val < 0:
+                raise ValueError
+            return val
+        except Exception:
+            raise ValueError(f'Некорректное значение: {name}')
 
-    x_dim, y_dim, z_dim = dims
-    orig_max_dim = float(max(dims))
-    volume_cm3 = volume_mm3 / 1000.0  # 1 cm^3 = 1000 mm^3
+    try:
+        price_filament = get_param('price_filament', 4)
+        price_resin = get_param('price_resin', 14)
+        time_coef_fdm = get_param('time_coef_fdm', 0.04)
+        time_coef_dlp = get_param('time_coef_dlp', 0.02)
+        price_machine_hour = get_param('price_machine_hour', 150)
+    except ValueError as e:
+        return jsonify(error=str(e)), 400
 
-    target_dim = st.number_input(
-        "Целевой наибольший габарит модели, мм",
-        min_value=0.0,
-        value=orig_max_dim,
-        format="%f"
-    )
-
-    if target_dim <= 0:
-        st.warning("Укажите положительное значение габарита")
-        st.stop()
-
-    scale = target_dim / orig_max_dim
+    max_dim = max(bbox)
+    scale = target_dim / max_dim
+    volume_cm3 = volume_mm3 / 1000.0
     scaled_volume_cm3 = volume_cm3 * (scale ** 3)
 
-    st.header("Параметры стоимости")
-    col1, col2 = st.columns(2)
-    with col1:
-        price_filament = st.number_input("Цена филамента, ₽/см³", min_value=0.0, value=4.0, step=0.1)
-        time_coef_fdm = st.number_input("Коэфф. машинного времени FDM, ч/см³", min_value=0.0, value=0.04, step=0.01)
-    with col2:
-        price_resin = st.number_input("Цена смолы, ₽/см³", min_value=0.0, value=14.0, step=0.1)
-        time_coef_dlp = st.number_input("Коэфф. машинного времени DLP, ч/см³", min_value=0.0, value=0.02, step=0.01)
-    price_machine_hour = st.number_input("Цена машинного часа, ₽/ч", min_value=0.0, value=150.0, step=1.0)
+    cost_fdm = scaled_volume_cm3 * price_filament + scaled_volume_cm3 * time_coef_fdm * price_machine_hour
+    cost_dlp = scaled_volume_cm3 * price_resin + scaled_volume_cm3 * time_coef_dlp * price_machine_hour
 
-    params = {
-        'price_filament': price_filament,
-        'price_resin': price_resin,
-        'time_coef_fdm': time_coef_fdm,
-        'time_coef_dlp': time_coef_dlp,
-        'price_machine_hour': price_machine_hour,
-    }
+    return jsonify({
+        'x_dim': bbox[0],
+        'y_dim': bbox[1],
+        'z_dim': bbox[2],
+        'scale': scale,
+        'v_scaled': scaled_volume_cm3,
+        'cost_fdm': cost_fdm,
+        'cost_dlp': cost_dlp
+    })
 
-    cost_fdm, cost_dlp = compute_costs(scaled_volume_cm3, params)
 
-    st.subheader("Параметры модели")
-    table = {
-        "Размер X, мм": [round(x_dim, 2)],
-        "Размер Y, мм": [round(y_dim, 2)],
-        "Размер Z, мм": [round(z_dim, 2)],
-        "Масштаб": [round(scale, 3)],
-        "Объём, см³": [round(scaled_volume_cm3, 2)]
-    }
-    st.table(table)
-
-    st.subheader("Расчёт стоимости")
-    colF, colD = st.columns(2)
-    colF.metric("FDM печать (₽)", f"{cost_fdm:,.2f}")
-    colD.metric("DLP печать (₽)", f"{cost_dlp:,.2f}")
-else:
-    st.info("Загрузите STL-файл для начала")
+if __name__ == '__main__':
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-streamlit
+flask
 trimesh
 numpy-stl
 numpy
+Werkzeug>=3.0

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,26 @@
+document.getElementById('estimate-form').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const form = e.target;
+    const data = new FormData(form);
+    try {
+        const resp = await fetch('/estimate', {
+            method: 'POST',
+            body: data
+        });
+        const json = await resp.json();
+        if (!resp.ok) {
+            alert(json.error || 'Ошибка сервера');
+            return;
+        }
+        document.getElementById('fdm-cost').textContent = json.cost_fdm.toFixed(2);
+        document.getElementById('dlp-cost').textContent = json.cost_dlp.toFixed(2);
+        const tableBody = document.getElementById('result-table');
+        tableBody.innerHTML = '';
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${json.x_dim.toFixed(2)}</td><td>${json.y_dim.toFixed(2)}</td><td>${json.z_dim.toFixed(2)}</td><td>${json.scale.toFixed(3)}</td><td>${json.v_scaled.toFixed(2)}</td>`;
+        tableBody.appendChild(row);
+        document.getElementById('results').style.display = 'block';
+    } catch (err) {
+        alert('Ошибка: ' + err.message);
+    }
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,4 @@
+#results .card-title {
+    font-size: 1.5rem;
+    font-weight: bold;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>3D-Print Cost Estimator</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <h1 class="mb-4">3D-Print Cost Estimator</h1>
+    <form id="estimate-form" enctype="multipart/form-data">
+        <div class="mb-3">
+            <label for="stl_file" class="form-label">Загрузите STL-файл</label>
+            <input class="form-control" type="file" id="stl_file" name="stl_file" accept=".stl" required>
+        </div>
+        <div class="mb-3">
+            <label for="target_dim" class="form-label">Целевой наибольший габарит, мм</label>
+            <input class="form-control" type="number" id="target_dim" name="target_dim" step="0.01" min="0.01" required>
+        </div>
+        <h5>Параметры стоимости</h5>
+        <div class="row">
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label class="form-label">Цена филамента, ₽/см³</label>
+                    <input class="form-control" type="number" step="0.01" name="price_filament" value="4" min="0">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Коэф. машинного времени FDM, ч/см³</label>
+                    <input class="form-control" type="number" step="0.01" name="time_coef_fdm" value="0.04" min="0">
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="mb-3">
+                    <label class="form-label">Цена смолы, ₽/см³</label>
+                    <input class="form-control" type="number" step="0.01" name="price_resin" value="14" min="0">
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Коэф. машинного времени DLP, ч/см³</label>
+                    <input class="form-control" type="number" step="0.01" name="time_coef_dlp" value="0.02" min="0">
+                </div>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Цена машинного часа, ₽/ч</label>
+            <input class="form-control" type="number" step="0.01" name="price_machine_hour" value="150" min="0">
+        </div>
+        <button class="btn btn-primary" type="submit">Рассчитать</button>
+    </form>
+
+    <div id="results" class="mt-4" style="display:none;">
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card text-center mb-3">
+                    <div class="card-header">FDM печать (₽)</div>
+                    <div class="card-body">
+                        <h5 id="fdm-cost" class="card-title"></h5>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card text-center mb-3">
+                    <div class="card-header">DLP печать (₽)</div>
+                    <div class="card-body">
+                        <h5 id="dlp-cost" class="card-title"></h5>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Размер X, мм</th>
+                    <th>Размер Y, мм</th>
+                    <th>Размер Z, мм</th>
+                    <th>Масштаб</th>
+                    <th>Объём, см³</th>
+                </tr>
+            </thead>
+            <tbody id="result-table"></tbody>
+        </table>
+    </div>
+</div>
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- migrate calculator logic from Streamlit to Flask
- implement HTML template and JS for AJAX form
- add simple styling
- update dependencies

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py` *(launched server)*

------
https://chatgpt.com/codex/tasks/task_e_685054594b3483339937311888c4424c