### PR TITLE
Fix STL loader import paths and mobile meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>3D-Print Cost Estimator</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 <link rel="stylesheet" href="css/styles.css" />

--- a/js/lib/OrbitControls.js
+++ b/js/lib/OrbitControls.js
@@ -9,7 +9,7 @@ import {
 	Plane,
 	Ray,
 	MathUtils
-} from 'three';
+} from './three.module.min.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).

--- a/js/lib/STLLoader.js
+++ b/js/lib/STLLoader.js
@@ -6,7 +6,7 @@ import {
 	Float32BufferAttribute,
 	Loader,
 	Vector3
-} from 'three';
+} from './three.module.min.js';
 
 /**
  * Description: A THREE loader for STL ASCII files, as created by Solidworks and other CAD programs.


### PR DESCRIPTION
## Summary
- fix STL loader import to use local three module
- fix OrbitControls import
- add viewport meta tag for mobile support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685087bfe5ac83339dddede695c777c0